### PR TITLE
recommended resources alignment wrt issue #106

### DIFF
--- a/Public/styles/result.css
+++ b/Public/styles/result.css
@@ -210,9 +210,14 @@ body {
   margin-bottom: 1rem;  /* Add space below the header */
 }
 
+.resource-list{
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .resource-card {
   display: inline-block;  /* Make cards appear side-by-side */
-  width: calc(20% - 1rem);  /* Set width to 20% of available space with 1rem margin */
+  width: calc(40% - 1rem);  /* Set width to 20% of available space with 1rem margin */
   margin: 0.5rem;  /* Add some margin between cards */
   padding: 1rem;  /* Add padding inside cards */
   border: 1px solid #ddd;  /* Add a thin border */


### PR DESCRIPTION
@Aryainguz Sorry to say that I am unable to solve the issue #106 as there were difference in the result page which was shown on your website https://euphoria-check-perma-meter-express.vercel.app/ and the result page which I open in my local repo. Unfortunately I was unable to find why it was showing like that underneath are the ss for both the pages.

on your website
![image](https://github.com/Open-Source-Chandigarh/Euphoria-Check/assets/137604220/38b47d4c-bbe7-4d3a-96ae-205d894950d4)

on my local repo
![Screenshot 2024-05-18 145953](https://github.com/Open-Source-Chandigarh/Euphoria-Check/assets/137604220/d57e59bb-ced2-4ba5-ae3a-a74c736d6664)

But while going through your repo I found an issue of misalignment of "recommended recourses" section where the content was overflowing. So I fixed it instead. Kindly consider this contribution under GSSOC'24. Thank you, hope you will understand.
before
![Screenshot 2024-05-18 150243](https://github.com/Open-Source-Chandigarh/Euphoria-Check/assets/137604220/bd499973-e45e-43ac-bce7-05c7fda09129)
after
![Screenshot 2024-05-18 150818](https://github.com/Open-Source-Chandigarh/Euphoria-Check/assets/137604220/da36a24d-796c-4701-abf1-b1c95ff51eb0)
